### PR TITLE
Two Items: Fix z-index problem and dynamic viewport units

### DIFF
--- a/cleaning.html
+++ b/cleaning.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
+            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
-            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/hanging.html
+++ b/hanging.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
+            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
-            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -2,8 +2,8 @@
     box-sizing: border-box;
 }
 body {
-    width: 100vw;
-    min-height: 100vh;
+    width: 100dvw;
+    min-height: 100dvh;
     margin: 0;
     padding: 0.5rem 2rem;
     position: relative;

--- a/identifying.html
+++ b/identifying.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
+            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
-            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/nectar.html
+++ b/nectar.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
+            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
-            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>


### PR DESCRIPTION
On a phone, the "Back to Guide" link laid underneath the hummingbird image so that it was not clickable.  Rearranging the order of the link and image so that the link comes after the image in each html file makes the link lie above the image, making it clickable.

On a phone, the footer containing the "Back to Guide" and hummingbird image hide below the bottom url bar.  Use the new dynamic viewport units, dvw and dvh instead of vw and vh, so that the footer is not hidden.