### PR TITLE
Mobile design changes

### DIFF
--- a/hummingbird.css
+++ b/hummingbird.css
@@ -37,12 +37,11 @@ nav {
     margin: 1rem 0;
 }
 #back {
-    width: calc(100vw - 4rem);
     font-size: 1.5rem;
     font-family: 'Kaushan Script', cursive;
-    text-align: center;
     position: absolute;
     bottom: 1rem;
+    left: 2rem;
 }
 footer img {
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <p>The most common hummingbirds in Ridgecrest are ...</p>
         </nav>
         <footer>
-            <img width="252px" src="images/background-image.png" alt="bright blue hummingbird">
+            <img width="200px" src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>


### PR DESCRIPTION
1.  Make hummingbird image smaller.  The hummingbird beak was covering text on mobile view.
2. Move "Back to Guide" link to far left side.  The link is too close to the hummingbird image on mobile view.