### PR TITLE
Begin fix of problem of footer overlaying content on longer than full-length pages

### DIFF
--- a/cleaning.html
+++ b/cleaning.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
-            <img src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
+            <img src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/hanging.html
+++ b/hanging.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
-            <img src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
+            <img src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -40,6 +40,12 @@ nav {
     font-size: 1.2rem;
     padding: 5px;
 }
+footer {
+    width: 100%;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+}
 #back {
     font-size: 1.5rem;
     font-family: 'Kaushan Script', cursive;

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -50,8 +50,7 @@ footer {
     font-size: 1.5rem;
     font-family: 'Kaushan Script', cursive;
     position: absolute;
-    bottom: 1rem;
-    left: 2rem;
+    bottom: 0;
 }
 footer img {
     width: 50vw;

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -35,6 +35,7 @@ p {
 }
 nav {
     margin: 1rem 0;
+    z-index: 2;
 }
 .bird-list li {
     font-size: 1.2rem;
@@ -80,8 +81,6 @@ footer img {
 @media screen and (min-width: 820px) {
     footer img {
         width: 25vw;
-        bottom: 5rem;
-        right: 5rem;
     }
 }
 /* media query for larger desktops */

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -49,9 +49,6 @@ nav {
 }
 footer img {
     width: 50vw;
-    position: absolute;
-    bottom: 0.5rem;
-    right: 0.5rem;
 }
 /* media query for tablets */
 @media screen and (min-width: 600px) {

--- a/identifying.html
+++ b/identifying.html
@@ -30,10 +30,10 @@
             </article>
         </main>
         <footer>
-            <img src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
+            <img src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,9 @@
             <p>The most common hummingbirds in Ridgecrest are ...</p>
         </nav>
         <footer>
+            <nav>
+                <a id="back" href="index.html"></a>
+            </nav>
             <img src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>

--- a/nectar.html
+++ b/nectar.html
@@ -18,10 +18,10 @@
             </div>
         </header>
         <footer>
-            <img src="images/background-image.png" alt="bright blue hummingbird">
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>
             </nav>
+            <img src="images/background-image.png" alt="bright blue hummingbird">
         </footer>
     </body>
 </html>


### PR DESCRIPTION
The Back Again link and hummingbird image were originally absolutely positioned so that they sit at the bottom of the screen when the html pages' content was short.  Once the content is longer than a page, they overlay the content because absolute positioning removes an element from the flow of content.

A beginning fix is to remove the absolute positioning.  Now the link and image need to be positioned differently.  The footer becomes a flexbox with the link and image becoming flex items that are justified space between to push them to the outer ends of the flexbox.  Originally, the link came last in the html file so it would have a higher z-index than the image.  The order is now reversed so the link is on the left and the image on the right.  To move the link to the bottom of page, footer is relatively positioned and link is absolutely positioned to the bottom of the footer. 

The problem remains that when the content is shorter than the length of the page, the footer does not move to the bottom.