### PR TITLE
Finish fix of problem of footer overlaying content on longer than full-length pages

### DIFF
--- a/cleaning.html
+++ b/cleaning.html
@@ -9,6 +9,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap"> 
         <link rel="stylesheet" href="hummingbird.css">
+        <script defer src="hummingbird.js"></script>
     </head>
     <body>
         <header>

--- a/cleaning.html
+++ b/cleaning.html
@@ -18,6 +18,7 @@
                 <h2>Fresh and Mold Free</h2>
             </div>
         </header>
+        <div id="vertical-spacer"></div>
         <footer>
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>

--- a/hanging.html
+++ b/hanging.html
@@ -9,6 +9,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap"> 
         <link rel="stylesheet" href="hummingbird.css">
+        <script defer src="hummingbird.js"></script>
     </head>
     <body>
         <header>

--- a/hanging.html
+++ b/hanging.html
@@ -18,6 +18,7 @@
                 <h2>What to Look For</h2>
             </div>
         </header>
+        <div id="vertical-spacer"></div>
         <footer>
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>

--- a/hummingbird.css
+++ b/hummingbird.css
@@ -3,7 +3,6 @@
 }
 body {
     width: 100dvw;
-    min-height: 100dvh;
     margin: 0;
     padding: 0.5rem 2rem;
     position: relative;

--- a/hummingbird.js
+++ b/hummingbird.js
@@ -1,0 +1,9 @@
+const html = document.querySelector("html");
+const body = document.querySelector("body");
+const verticalSpacer = document.querySelector("#vertical-spacer");
+
+let spacerHeight = html.clientHeight - body.clientHeight;
+console.log(html.clientHeight);
+console.log(body.clientHeight);
+console.log(spacerHeight);
+verticalSpacer.style.height = `${spacerHeight}px`;

--- a/identifying.html
+++ b/identifying.html
@@ -9,6 +9,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap"> 
         <link rel="stylesheet" href="hummingbird.css">
+        <script defer src="hummingbird.js"></script>
     </head>
     <body>
         <header>

--- a/identifying.html
+++ b/identifying.html
@@ -30,6 +30,7 @@
                 </ol>
             </article>
         </main>
+        <div id="vertical-spacer"></div>
         <footer>
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap"> 
         <link rel="stylesheet" href="hummingbird.css">
+        <script defer src="hummingbird.js"></script>
     </head>
     <body>
         <header>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             <h3><a href="identifying.html">Identifying Your Birds</a></h3>
             <p>The most common hummingbirds in Ridgecrest are ...</p>
         </nav>
+        <div id="vertical-spacer"></div>
         <footer>
             <nav>
                 <a id="back" href="index.html"></a>

--- a/nectar.html
+++ b/nectar.html
@@ -18,6 +18,7 @@
                 <h2>Simple, Cheap, and Dye Free</h2>
             </div>
         </header>
+        <div id="vertical-spacer"></div>
         <footer>
             <nav>
                 <a id="back" href="index.html">Back to Guide</a>

--- a/nectar.html
+++ b/nectar.html
@@ -9,6 +9,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Kaushan+Script&display=swap"> 
         <link rel="stylesheet" href="hummingbird.css">
+        <script defer src="hummingbird.js"></script>
     </head>
     <body>
         <header>


### PR DESCRIPTION
Add a vertical space div whose height is calculated by subtracting the body height from the device height.  This add the correct amount of space to move the footer to the bottom of the device height if the body content is shorter than the device height.